### PR TITLE
Edit names

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,13 +3,16 @@
 
         <edit-button :toggle-edit="toggleEdit" :edit-mode="editMode"/>
         
-        <game-progress
+        <game-progress v-if="!editMode"
                 :score-left="scoreLeft" :score-right="scoreRight" :server="server"
                 v-on:increase-left="increaseLeft"
                 v-on:decrease-left="decreaseLeft"
                 v-on:increase-right="increaseRight"
-                v-on:decrease-right="decreaseRight"
-                :edit-mode="editMode"></game-progress>
+                v-on:decrease-right="decreaseRight"/>
+
+        <game-progress-edit v-if="editMode"
+                :score-left="scoreLeft" 
+                :score-right="scoreRight"/>
 
         <score-footer
                     :player-left.sync="playerLeft"
@@ -25,15 +28,17 @@
 </template>
 <script>
     import gameProgress from './components/game-progress.vue';
+    import gameProgressEdit from './components/game-progress-edit.vue';
     import scoreFooter from './components/score-footer.vue';
     import gameSummary from './components/game-summary.vue';
     import matchSummary from './components/match-summary.vue';
-    import "./assets/score-view.styl";
     import editButton from './components/edit-button.vue';
+    import "./assets/score-view.styl";
 
     export default {
         components: {
             'game-progress': gameProgress,
+            'game-progress-edit': gameProgressEdit,
             'score-footer': scoreFooter,
             'game-summary': gameSummary,
             'match-summary': matchSummary,
@@ -50,11 +55,21 @@
             playerRight: 'Zhang Z.',
             gameWinner: false,
             matchWinner: false,
-            editMode: false
+            editMode: false,
+            newServer: null,
+            swapServer: false
         }},
 
         computed: {
             server: function() {
+                let server = this.defaultServer;
+                if (this.swapServer) {
+                    return server == 'left' ? 'right' : 'left';
+                }
+                return server;
+            },
+
+            defaultServer: function() {
                 let totalPoints = this.scoreLeft + this.scoreRight;
                 if (this.scoreLeft < 10 || this.scoreRight < 10) {
                     let serveTurns = ~~(totalPoints /2);
@@ -154,7 +169,15 @@
 
             toggleEdit: function() {
                 this.editMode = !this.editMode;
-            }
+                if (this.editMode) {
+                    let currentServer = this.server;
+                    this.newServer = currentServer;
+                } else {
+                    this.swapServer = this.newServer != this.defaultServer;
+                }
+            },
+
+            
         }
     }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -143,14 +143,9 @@
                 this.scoreRight = 0;
             },
 
-            resetServer: function() {
-                this.server = 'left';
-            },
-
             startGame: function() {
                 this.swapSides();
                 this.resetScore();
-                this.resetServer();
                 this.gameWinner = false;
             },
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,8 @@
                 v-on:increase-left="increaseLeft"
                 v-on:decrease-left="decreaseLeft"
                 v-on:increase-right="increaseRight"
-                v-on:decrease-right="decreaseRight"></game-progress>
+                v-on:decrease-right="decreaseRight"
+                :edit-mode="editMode"></game-progress>
 
         <score-footer
                     :player-left.sync="playerLeft"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,8 @@
 <template>
     <div class="container" @keyup.enter="toggleEdit">
-        <div class="edit-button">
-            <div v-on:click="toggleEdit">...</div>
-        </div>
+
+        <edit-button :toggle-edit="toggleEdit" :edit-mode="editMode"/>
+        
         <game-progress
                 :score-left="scoreLeft" :score-right="scoreRight" :server="server"
                 v-on:increase-left="increaseLeft"
@@ -29,13 +29,15 @@
     import gameSummary from './components/game-summary.vue';
     import matchSummary from './components/match-summary.vue';
     import "./assets/score-view.styl";
+    import editButton from './components/edit-button.vue';
 
     export default {
         components: {
             'game-progress': gameProgress,
             'score-footer': scoreFooter,
             'game-summary': gameSummary,
-            'match-summary': matchSummary
+            'match-summary': matchSummary,
+            'edit-button': editButton
         },
 
         data: () => { return {

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,11 +11,14 @@
                 v-on:decrease-right="decreaseRight"></game-progress>
 
         <score-footer
-                    :player-left="playerLeft" :player-right="playerRight" :game-scores="gameScores"
+                    :player-left.sync="playerLeft"
+                    :player-right.sync="playerRight" 
+                    :game-scores="gameScores"
                     :game-winner="gameWinner"
                     :match-winner="matchWinner"
                     :start-game="startGame"
                     :finish-match="finishMatch"
+                    :edit-mode="editMode"
                     ></score-footer>
     </div>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,8 @@
 <template>
     <div class="container">
+        <div class="edit-button">
+            <div v-on:click="handleEdit">...</div>
+        </div>
         <game-progress
                 :score-left="scoreLeft" :score-right="scoreRight" :server="server"
                 v-on:increase-left="increaseLeft"
@@ -41,6 +44,7 @@
             playerRight: 'Zhang Z.',
             gameWinner: false,
             matchWinner: false,
+            editMode: false
         }},
 
         computed: {
@@ -140,6 +144,10 @@
 
             rightWinsGame: function() {
                 return this.scoreRight >= 11 && this.scoreRight - this.scoreLeft > 1
+            },
+
+            handleEdit: function() {
+                this.editMode = !this.editMode;
             }
         }
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
-    <div class="container">
+    <div class="container" @keyup.enter="toggleEdit">
         <div class="edit-button">
-            <div v-on:click="handleEdit">...</div>
+            <div v-on:click="toggleEdit">...</div>
         </div>
         <game-progress
                 :score-left="scoreLeft" :score-right="scoreRight" :server="server"
@@ -150,7 +150,7 @@
                 return this.scoreRight >= 11 && this.scoreRight - this.scoreLeft > 1
             },
 
-            handleEdit: function() {
+            toggleEdit: function() {
                 this.editMode = !this.editMode;
             }
         }

--- a/src/assets/score-view.styl
+++ b/src/assets/score-view.styl
@@ -36,6 +36,7 @@ flex-row(horizontalLayout) {
 
 html {
     height: 100%;
+    text-align: right;
 }
 
 body {
@@ -53,9 +54,15 @@ body {
     flex-column(center);
     align-items: center;
     width: 100%;
-    height: 90vmin;
+    height: 100vmin;
     margin-top: 10px;
     user-select: none;
+  }
+
+  .edit-button {
+    font-size: 5vmin;
+    width: 90%;
+    flex-row(flex-end);
   }
 
   .score-container {

--- a/src/assets/score-view.styl
+++ b/src/assets/score-view.styl
@@ -130,7 +130,12 @@ body {
         margin-right: 10px;
       }
     }
-  }
+
+    .player-name-input {
+      font-size: 4vmin;
+      width: 40vmin;
+      margin-bottom: 2vmin;}
+    }
 }
 
 .game-winner {

--- a/src/assets/score-view.styl
+++ b/src/assets/score-view.styl
@@ -98,6 +98,7 @@ body {
     .server-option {
       width: 4vmin;
       height: 4vmin;
+      margin-right: 2vmin;
     }
   }
 

--- a/src/assets/score-view.styl
+++ b/src/assets/score-view.styl
@@ -94,6 +94,11 @@ body {
     .serve-indicator {
       font-size: 20vmin;
     }
+
+    .server-option {
+      width: 4vmin;
+      height: 4vmin;
+    }
   }
 
   .score-left {

--- a/src/components/edit-button.vue
+++ b/src/components/edit-button.vue
@@ -1,0 +1,11 @@
+<template>
+    <div class="edit-button">
+        <div @click="toggleEdit">...</div>
+    </div>
+</template>
+
+<script>
+export default {
+    props: ["toggleEdit", "editMode"]
+}
+</script>

--- a/src/components/game-progress-edit.vue
+++ b/src/components/game-progress-edit.vue
@@ -26,7 +26,7 @@
 </template>
 <script>
 export default {
-    props: ['scoreLeft', 'scoreRight', 'newServer'],
+    props: ['scoreLeft', 'scoreRight'],
     computed: {
         valClass: function() {
             let valueSize = (this.scoreLeft > 9 || this.scoreRight > 9) ? "small" : "normal";

--- a/src/components/game-progress-edit.vue
+++ b/src/components/game-progress-edit.vue
@@ -1,0 +1,38 @@
+<template>
+    <div class="score-container" >
+        <div class="score-left">
+            <div class="score-val">
+                <span :class="valClass">{{scoreLeft}} </span>
+                <input type="radio" 
+                    name="server" value="left"
+                    class="server-option"
+                    v-model="$parent.newServer"
+                    />
+            </div>
+            <div class="btn-minus">-</div>
+        </div>
+        <div class="score-right">
+            <div class="score-val">
+                <span :class="valClass">{{scoreRight}}</span>
+                <input type="radio" 
+                    name="server" value="right" 
+                    class="server-option"
+                    v-model="$parent.newServer"
+                    />
+            </div>
+            <div class="btn-minus">-</div>
+        </div>
+    </div>
+</template>
+<script>
+export default {
+    props: ['scoreLeft', 'scoreRight', 'newServer'],
+    computed: {
+        valClass: function() {
+            let valueSize = (this.scoreLeft > 9 || this.scoreRight > 9) ? "small" : "normal";
+            return "score-val-number " + valueSize;
+        }
+    }
+};
+
+</script>

--- a/src/components/game-progress.vue
+++ b/src/components/game-progress.vue
@@ -3,9 +3,8 @@
         <div class="score-left" v-on:click="$emit('increase-left')">
             <div class="score-val">
                 <span :class="valClass">{{scoreLeft}} </span>
-                
-                <span v-if="!editMode" class="serve-indicator">{{server === 'left' ? "'" : ""}}</span>
-                <input v-if="editMode" type="radio" name="server" value="left" v-model="server" class="server-option"/>
+
+                <span class="serve-indicator">{{server === 'left' ? "'" : ""}}</span>
             </div>
             <div class="btn-minus" v-on:click.stop="$emit('decrease-left')">-</div>
         </div>
@@ -13,8 +12,7 @@
             <div class="score-val">
                 <span :class="valClass">{{scoreRight}} </span>
                 
-                <span v-if="!editMode" class="serve-indicator">{{server === 'right' ? "'" : ""}}</span>
-                <input v-if="editMode" type="radio" name="server" value="right" v-model="server" class="server-option"/>
+                <span class="serve-indicator">{{server === 'right' ? "'" : ""}}</span>
             </div>
             <div class="btn-minus" v-on:click.stop="$emit('decrease-right')">-</div>
         </div>
@@ -22,7 +20,7 @@
 </template>
 <script>
 export default {
-    props: ['scoreLeft', 'scoreRight','server', 'editMode'],
+    props: ['scoreLeft', 'scoreRight','server'],
     computed: {
         valClass: function() {
             let valueSize = (this.scoreLeft > 9 || this.scoreRight > 9) ? "small" : "normal";

--- a/src/components/game-progress.vue
+++ b/src/components/game-progress.vue
@@ -18,7 +18,7 @@
 </template>
 <script>
 export default {
-    props: ['scoreLeft', 'scoreRight','server'],
+    props: ['scoreLeft', 'scoreRight','server', 'editMode'],
     computed: {
         valClass: function() {
             let valueSize = (this.scoreLeft > 9 || this.scoreRight > 9) ? "small" : "normal";

--- a/src/components/game-progress.vue
+++ b/src/components/game-progress.vue
@@ -3,14 +3,18 @@
         <div class="score-left" v-on:click="$emit('increase-left')">
             <div class="score-val">
                 <span :class="valClass">{{scoreLeft}} </span>
-                <span class="serve-indicator">{{server === 'left' ? "'" : ""}}</span>
+                
+                <span v-if="!editMode" class="serve-indicator">{{server === 'left' ? "'" : ""}}</span>
+                <input v-if="editMode" type="radio" name="server" value="left" v-model="server" class="server-option"/>
             </div>
             <div class="btn-minus" v-on:click.stop="$emit('decrease-left')">-</div>
         </div>
         <div class="score-right" v-on:click="$emit('increase-right')">
             <div class="score-val">
                 <span :class="valClass">{{scoreRight}} </span>
-                <span class="serve-indicator">{{server === 'right' ? "'" : ""}}</span>
+                
+                <span v-if="!editMode" class="serve-indicator">{{server === 'right' ? "'" : ""}}</span>
+                <input v-if="editMode" type="radio" name="server" value="right" v-model="server" class="server-option"/>
             </div>
             <div class="btn-minus" v-on:click.stop="$emit('decrease-right')">-</div>
         </div>

--- a/src/components/score-footer.vue
+++ b/src/components/score-footer.vue
@@ -1,7 +1,11 @@
 
 <template>
 <div class="score-footer">
-    <div class="player-name">{{playerLeft}}</div>
+    <input v-if="editMode" 
+      :value="playerLeft" 
+      placeholder="player name" 
+      @input="$emit('update:playerLeft', $event.target.value)">
+    <div v-if="!editMode" class="player-name">{{playerLeft}}</div>
    
     <a href="#" v-if="matchWinner" v-on:click="finishMatch" >Finish match</a>
 
@@ -10,7 +14,12 @@
     <div v-if="!gameWinner && !matchWinner" class="game-scores">
         <game-score v-for="item of gameScores" :game-score="item" v-bind:key="item"/>
     </div>
-    <div class="player-name">{{playerRight}}</div>
+
+    <input v-if="editMode" 
+      placeholder="player name"
+      :value="playerRight" 
+      @input="$emit('update:playerRight', $event.target.value)">
+    <div v-if="!editMode" class="player-name">{{playerRight}}</div>
 </div>
 
 </template>
@@ -21,6 +30,6 @@ export default {
   components: {
     "game-score": gameScore
   },
-  props: ["playerLeft", "playerRight", "gameScores", "gameWinner", "matchWinner", "startGame", "finishMatch"]
+  props: ["playerLeft", "playerRight", "gameScores", "gameWinner", "matchWinner", "startGame", "finishMatch", "editMode"]
 };
 </script>

--- a/src/components/score-footer.vue
+++ b/src/components/score-footer.vue
@@ -1,24 +1,29 @@
 
 <template>
 <div class="score-footer">
+
     <input v-if="editMode" 
       :value="playerLeft" 
-      placeholder="player name" 
+      class="player-name-input"
+      placeholder="Player name" 
       @input="$emit('update:playerLeft', $event.target.value)">
+
     <div v-if="!editMode" class="player-name">{{playerLeft}}</div>
    
-    <a href="#" v-if="matchWinner" v-on:click="finishMatch" >Finish match</a>
+    <a href="#" v-if="matchWinner" @click="finishMatch" >Finish match</a>
 
-    <a href="#" v-if="gameWinner && !matchWinner" v-on:click="startGame">Next game</a>
+    <a href="#" v-if="gameWinner && !matchWinner" @click="startGame">Next game</a>
 
     <div v-if="!gameWinner && !matchWinner" class="game-scores">
         <game-score v-for="item of gameScores" :game-score="item" v-bind:key="item"/>
     </div>
 
     <input v-if="editMode" 
-      placeholder="player name"
       :value="playerRight" 
+      class="player-name-input"
+      placeholder="Player name"
       @input="$emit('update:playerRight', $event.target.value)">
+
     <div v-if="!editMode" class="player-name">{{playerRight}}</div>
 </div>
 


### PR DESCRIPTION
**What?**
Allowed editing player names and current server

**Why?**
Because players are not called Harimoto in the Cambs league and not always the left one starts serving

**Tested?**
Manually verified player names are updated after editing
Server side is updated after editing 
When the game starts with the right player serving then consequent games also start with the right player serving
Clicking enter when in the player name input results in exiting edit mode